### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To launch this example you should install Ruby and the allure-rspec gem.
 ### 3. Install Ruby
 
 ```bash
-rbenv install 3.0.0
+rbenv install
 ```
 
 ### 4. Install bundler


### PR DESCRIPTION
current ruby version is 3.0.2 but README says 3.0.0
README need not specify ruby version since This repository has `.ruby-version`.